### PR TITLE
Prevent ack null error and close #97

### DIFF
--- a/main.js
+++ b/main.js
@@ -129,6 +129,7 @@ function startAdapter(options) {
 
                 function handleParam(idState, prefill) {
                     if (idStates[idState] === undefined) return;
+                    if (idStates[idState] === null) return;
                     if (prefill && !idStates[idState].ack) return;
 
                     const idtmp = idState.split('.');


### PR DESCRIPTION
This fixed the issue for my local iobroker by validating that `idStates[idState]` is not `null`.