### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "Bluefox <dogafox@gmail.com>",
     "Moritz Heusinger <moritz.heusinger@gmail.com>"
   ],
-  "engines": {
-    "node": ">=10"
-  },
   "homepage": "https://github.com/iobroker-community-adapters/ioBroker.hue",
   "license": "Apache-2.0",
   "keywords": [
@@ -26,6 +23,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/iobroker-community-adapters/ioBroker.hue"
+  },
+  "engines": {
+    "node": ">=16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
adapter-core 3.x.x is know to fail during install at node 14 and before (due to npm 6 not installing peerDependencies.
So this adapter should require node 16 or higher.

Please increment at least minor version number with next release due to node requirement change ('best praxis')